### PR TITLE
Fixing US-based meetups

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -259,8 +259,8 @@ toc::[]
 === America
 * http://www.meetup.com/Bay-Area-Kotlin-User-Group/[Bay Area Kotlin User Group^] - USA
 * http://www.meetup.com/Chicago-Kotlin-Users-Group/[Chicago Kotlin Users Group^] - USA
+* http://www.meetup.com/Kotlin-Group-Boulder/[Kotlin Group of Boulder^] - USA
 * http://www.meetup.com/New-York-Kotlin-Meetup/[New York Kotlin Meetup^] - USA
-* http://www.meetup.com/Bay-Area-Kotlin-User-Group/[Bay Area Kotlin User Group^] - USA
 
 === Asia
 * https://kotlin.doorkeeper.jp/[Japan Kotlin User Group^] - Japan

--- a/app/Kotlin.js
+++ b/app/Kotlin.js
@@ -1081,15 +1081,15 @@ const data = [{
             type: 'kug',
             tags: ['USA']
         }, {
-            name: 'New York Kotlin Meetup',
+            name: 'Kotlin Group of Boulder',
             desc: 'USA',
-            href: 'http://www.meetup.com/New-York-Kotlin-Meetup/',
+            href: 'http://www.meetup.com/Kotlin-Group-Boulder/',
             type: 'kug',
             tags: ['USA']
         }, {
-            name: 'Bay Area Kotlin User Group',
+            name: 'New York Kotlin Meetup',
             desc: 'USA',
-            href: 'http://www.meetup.com/Bay-Area-Kotlin-User-Group/',
+            href: 'http://www.meetup.com/New-York-Kotlin-Meetup/',
             type: 'kug',
             tags: ['USA']
         }]


### PR DESCRIPTION
I noticed that I accidentally had the Bay Area Meetup on the list twice. The missing one is Boulder, so I added that because it seems to have a lot of members and scheduled meetings.

As an aside, I'm really sorry about the back and forth on this! I appreciate this project, it's helped me find some good Kotlin resources while I'm learning.

---
+Removed duplicate Bay Area meetup.
+Really added Boulder this time.