### PR TITLE
Add AzaKotlinCSS into the Web-section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Here awesome badge for your project:
 * [taskworld/kraph](https://github.com/taskworld/kraph) - GraphQL request string builder written in Kotlin
 * [sepatel/tekniq](https://github.com/sepatel/tekniq) - Full-feature HTTP DSL Framework, HTTP Client, JDBC DSL, Loading Cache and Configuration
 * [vert-x3/vertx-lang-kotlin](https://github.com/vert-x3/vertx-lang-kotlin/) - This module provides Kotlin language bindings including DSL and extension functions for vert.x 3
+* [olegcherr/Aza-Kotlin-CSS](https://github.com/olegcherr/Aza-Kotlin-CSS) - Kotlin DSL for CSS
 
 ### <a name="libraries-frameworks-tests"></a>Tests <sup>[Back ⇈](#libraries-frameworks-tests-subcategory)</sup>
 * [JetBrains/spek](https://github.com/jetbrains/spek) - A specification framework for Kotlin.

--- a/app/Kotlin.ts
+++ b/app/Kotlin.ts
@@ -139,7 +139,7 @@ const data: Category[] = [{
       desc: 'Kotlin DSL for HTML.',
       href: 'https://github.com/Kotlin/kotlinx.html',
       type: 'github',
-      tags: ['html']
+      tags: ['web', 'html']
     }, {
       name: 'MarioAriasC/KotlinPrimavera',
       desc: 'Spring support libraries for Kotlin.',
@@ -182,6 +182,12 @@ const data: Category[] = [{
       href: 'https://github.com/vert-x3/vertx-lang-kotlin/',
       type: 'github',
       tags: ['web', 'vert.x']
+    }, {
+      name: 'olegcherr/Aza-Kotlin-CSS',
+      desc: 'Kotlin DSL for CSS',
+      href: 'https://github.com/olegcherr/Aza-Kotlin-CSS',
+      type: 'github',
+      tags: ['web', 'css']
     }]
   }, {
     name: 'Tests',

--- a/src/main/kotlin/link/kotlin/scripts/data/Libraries.kt
+++ b/src/main/kotlin/link/kotlin/scripts/data/Libraries.kt
@@ -38,7 +38,7 @@ val libraries = category("Libraries/Frameworks") {
       desc = "Kotlin DSL for HTML."
       href = "https://github.com/Kotlin/kotlinx.html"
       type = github
-      tags = Tags["html"]
+      tags = Tags["web", "html"]
     }
     link {
       name = "MarioAriasC/KotlinPrimavera"
@@ -88,6 +88,13 @@ val libraries = category("Libraries/Frameworks") {
       href = "https://github.com/vert-x3/vertx-lang-kotlin/"
       type = github
       tags = Tags["web", "vert.x"]
+    }
+    link {
+      name = "olegcherr/Aza-Kotlin-CSS"
+      desc = "Kotlin DSL for CSS"
+      href = "https://github.com/olegcherr/Aza-Kotlin-CSS"
+      type = github
+      tags = Tags["web", "css"]
     }
   }
   subcategory("Tests") {


### PR DESCRIPTION
The main purpose of [AzaKotlinCSS](https://github.com/olegcherr/Aza-Kotlin-CSS) is to generate CSS-files on the server side. So I think the library should be placed near other similar frameworks (e.g. Kara and kotlinx.html), not only in the JavaScript-section.