### PR TITLE
add kengorab/kotlin-javascript-boilerplate under JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Here awesome badge for your project:
 * [stangls/kotlin-js-jquery](https://github.com/stangls/kotlin-js-jquery) - A small framework for writing client -side web -applications in Kotlin.
 * [Kotlin/kotlin-fullstack-sample](https://github.com/Kotlin/kotlin-fullstack-sample) - Kotlin Full-stack Application Example.
 * [danfma/kodando](https://github.com/danfma/kodando) - Kotlin JS bindings and libraries.
+* [kengorab/kotlin-javascript-boilerplate](https://github.com/kengorab/kotlin-javascript-boilerplate) - An extremely barebones boilerplate project for compiling Kotlin to Javascript.
 
 ### <a name="kotlin-javascript-frontend"></a>Frontend <sup>[Back ⇈](#kotlin-javascript-frontend-subcategory)</sup>
 * [olegcherr/Aza-Kotlin-CSS](https://github.com/olegcherr/Aza-Kotlin-CSS) - Kotlin DSL for CSS

--- a/links/JavaScript.kts
+++ b/links/JavaScript.kts
@@ -48,6 +48,13 @@ category("Kotlin JavaScript") {
       type = github
       tags = Tags["bindings", "react", "mobx", "rxjs"]
     }
+    link {
+      name = "kengorab/kotlin-javascript-boilerplate"
+      desc = "An extremely barebones boilerplate project for compiling Kotlin to Javascript."
+      href = "https://github.com/kengorab/kotlin-javascript-boilerplate"
+      type = github
+      tags = Tags["boilerplate", "javascript", "kotlin2js"]
+    }
   }
   subcategory("Frontend") {
     link {


### PR DESCRIPTION
cc @kengorab

This is a great boilerplate app for people who are working with Kotlin -> JS, particularly, without any extra overhead or defacto coupling with JetBrains IDE (nothing against the IDE, but it helps to understanding plugins, build process without it).