### PR TITLE
Add Async/Await lib to the Coroutines section

### DIFF
--- a/links/Libraries.kts
+++ b/links/Libraries.kts
@@ -320,6 +320,13 @@ category("Libraries/Frameworks") {
       type = github
       tags = Tags["coroutines", "spring"]
     }
+    link {
+      name = "metalabdesign/AsyncAwait"
+      desc = "async/await for Android built upon coroutines introduced in Kotlin 1.1."
+      href = "https://github.com/metalabdesign/AsyncAwait"
+      type = github
+      tags = Tags["async", "await", "android"]
+    }
   }
   subcategory("Functional Programming") {
     link {


### PR DESCRIPTION
Async/Await lib is belonging both to Android and Coroutines sections. So I added it to Coroutines section as well.