### PR TITLE
Add kotlin-result to Libraries

### DIFF
--- a/links/Libraries.kts
+++ b/links/Libraries.kts
@@ -379,6 +379,13 @@ category("Libraries/Frameworks") {
       tags = Tags["fp", "functional", "UI", "Interface", "Redux"]
     }
     link {
+      name = "michaelbull/kotlin-result"
+      desc = "A Result monad for modelling success or failure operations - inspired by Elm, Rust, & Haskell."
+      href = "https://github.com/michaelbull/kotlin-result"
+      type = github
+      tags = Tags["fp", "functional", "result", "monad", "either", "type"]
+    }
+    link {
       name = "pakoito/Komprehensions"
       desc = "Do comprehensions for Kotlin and 3rd party libraries."
       href = "https://github.com/pakoito/Komprehensions"


### PR DESCRIPTION
A Result monad for modelling success or failure operations - inspired by Elm, Rust, & Haskell.