### PR TITLE
JFYI: mark "links" directory as a sources root in IDEA.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ configure<KotlinProjectExtension> {
     experimental.coroutines = Coroutines.ENABLE
 }
 
+java.sourceSets.create("links").java.srcDir("links")
+
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion")
     compile("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")


### PR DESCRIPTION
As you see, pretty hacky and not obvious. And it refers to "java", that is not semantically correct.

The other way to mark it as sources root would be to apply `idea` plugin and modify module's XML (`awesome-kotlin.iml`), using one of lifecycle hooks from https://docs.gradle.org/current/userguide/idea_plugin.html