### PR TITLE
Add example TodoMVC React + Kotlin.js project

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ Here awesome badge for your project:
 * [pakoito/FunctionalAndroidReference](https://github.com/pakoito/FunctionalAndroidReference) - A different Android app showcasing Functional Reactive Programming.
 * [bmaslakov/kotlin-algorithm-club](https://github.com/bmaslakov/kotlin-algorithm-club) - Classic algorithms and data structures in Kotlin.
 * [gyulavoros/kotlin-todomvc](https://github.com/gyulavoros/kotlin-todomvc) - Kotlin TodoMVC – full-stack Kotlin application demo
+* [mkraynov/todomvc-react-kotlin](https://github.com/mkraynov/todomvc-react-kotlin) - React Kotlin TodoMVC – example based on create-react-kotlin-app and todomvc-react
 
 ### <a name="projects-idea-plugins"></a>Idea Plugins <sup>[Back ⇈](#projects-idea-plugins-subcategory)</sup>
 * [Vektah/CodeGlance](https://github.com/Vektah/CodeGlance) - Intelij IDEA plugin for displaying a code mini-map similar to the one found in Sublime.

--- a/src/main/resources/links/Projects.kts
+++ b/src/main/resources/links/Projects.kts
@@ -285,7 +285,14 @@ category("Projects") {
       desc = "Kotlin TodoMVC – full-stack Kotlin application demo"
       href = "https://github.com/gyulavoros/kotlin-todomvc"
       type = github
-      tags = Tags["examples", "javascript", "web", "gradle"]
+      tags = Tags["examples", "javascript", "web", "gradle", "todomvc"]
+    }
+    link {
+      name = "mkraynov/todomvc-react-kotlin"
+      desc = "React Kotlin TodoMVC – example based on create-react-kotlin-app and todomvc-react"
+      href = "https://github.com/mkraynov/todomvc-react-kotlin"
+      type = github
+      tags = Tags["examples", "javascript", "web", "react", "todomvc"]
     }
   }
   subcategory("Idea Plugins") {


### PR DESCRIPTION
I've made an example implementation of TodoMVC in Kotlin + React based on create-react-kotlin-app and wont to add it in links.

Also I've added new tag "todomvc" to link across all todomvc implementations in Kotlin.