### PR TITLE
Fixing name of country (Swiss vs. Switzerland)

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Here awesome badge for your project:
 * [St. Petersburg Kotlin User Group](https://www.meetup.com/St-Petersburg-Kotlin-User-Group/) - Russia
 * [Serbia Kotlin User Group](https://www.meetup.com/Serbia-Kotlin-User-Group/) - Serbia
 * [Stockholm Kotlin User Group](https://www.meetup.com/Sweden-Kotlin-User-Group/) - Sweden
-* [Swiss Kotlin User Group](https://www.meetup.com/Kotlin-Swiss-User-Group/) - Swiss
+* [Swiss Kotlin User Group](https://www.meetup.com/Kotlin-Swiss-User-Group/) - Switzerland
 * [Toulouse Kotlin User Group](https://www.meetup.com/fr-FR/Toulouse-Kotlin-User-Group/) - France
 * [Utrecht Kotlin User Group](https://www.meetup.com/meetup-group-YgJEOzCn/) - Netherlands
 * [Uzhgorod Kotlin User Group](https://www.facebook.com/groups/135578123824203/) - Ukraine

--- a/src/main/resources/links/UserGroups.kts
+++ b/src/main/resources/links/UserGroups.kts
@@ -239,10 +239,10 @@ category("Kotlin User Groups") {
     }
     link {
       name = "Swiss Kotlin User Group"
-      desc = "Swiss"
+      desc = "Switzerland"
       href = "https://www.meetup.com/Kotlin-Swiss-User-Group/"
       type = kug
-      tags = Tags["Swiss"]
+      tags = Tags["Swiss", "Switzerland"]
     }
     link {
       name = "Toulouse Kotlin User Group"


### PR DESCRIPTION
Both country names are valid depending on their context, e.g. "The Kotlin Swiss User Group is meeting in Switzerland"