### PR TITLE
Remove Chennai Kotlin User Group.

### DIFF
--- a/src/main/resources/links/UserGroups.kts
+++ b/src/main/resources/links/UserGroups.kts
@@ -359,13 +359,6 @@ category("Kotlin User Groups") {
       tags = Tags["India"]
     }
     link {
-      name = "Chennai Kotlin User Group"
-      desc = "India"
-      href = "https://www.meetup.com/Chennai-Kotlin-User-Group/"
-      type = kug
-      tags = Tags["India"]
-    }
-    link {
       name = "Chengdu Kotlin User Group"
       desc = "China"
       href = "https://www.kotliner.cn/chengdu/"


### PR DESCRIPTION
Fixes #373 
Meetup group for Chennai Kotlin User Group does not exist, hence removed.
