### PR TITLE
Add pemistahl/lingua

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Here awesome badge for your project:
 * [ziggy42/kolor](https://github.com/ziggy42/kolor) - A library to print colored strings, with Kotlin.
 * [holgerbrandl/kravis](https://github.com/holgerbrandl/kravis) - A Kotlin grammar for scientific data visualization
 * [MiloszKrajewski/stateful4k](https://github.com/MiloszKrajewski/stateful4k) - State Machine Construction Kit for Kotlin
+* [pemistahl/lingua](https://github.com/pemistahl/lingua) - A language detection library suitable for long and short text alike
 
 ### <a name="libraries-frameworks-extensions"></a>Extensions <sup>[Back ⇈](#libraries-frameworks-extensions-subcategory)</sup>
 * [Kotlin/kotlinx.support](https://github.com/Kotlin/kotlinx.support) - Extension and top-level functions to use JDK7/JDK8 features in Kotlin 1.0.

--- a/src/main/resources/links/Libraries.kts
+++ b/src/main/resources/links/Libraries.kts
@@ -1235,6 +1235,13 @@ category("Libraries/Frameworks") {
       type = github
       tags = Tags["state machine"]
     }
+    link {
+      name = "pemistahl/lingua"
+      desc = "A language detection library suitable for long and short text alike"
+      href = "https://github.com/pemistahl/lingua"
+      type = github
+      tags = Tags["nlp", "natural-language-processing", "linguistics", "languages", "language-detection", "language-modeling", "machine-learning"]
+    }
   }
   subcategory("Extensions") {
     link {


### PR DESCRIPTION
Hello over there,

I'm a computational linguist who has developed a small Kotlin library for written language detection named [lingua](https://github.com/pemistahl/lingua). Compared to other libraries in this area, it aims to be especially accurate when it comes to detecting the language of short texts such as Twitter messages.

I'd be very happy if my library was added to this list as I think it is a useful tool already despite its young age.

Thanks a lot in advance!