### PR TITLE
Add kaml to list of libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Here awesome badge for your project:
 * [ziggy42/kolor](https://github.com/ziggy42/kolor) - A library to print colored strings, with Kotlin.
 * [holgerbrandl/kravis](https://github.com/holgerbrandl/kravis) - A Kotlin grammar for scientific data visualization
 * [MiloszKrajewski/stateful4k](https://github.com/MiloszKrajewski/stateful4k) - State Machine Construction Kit for Kotlin
+* [charleskorn/kaml](https://github.com/charleskorn/kaml) - YAML support for kotlinx.serialization
 
 ### <a name="libraries-frameworks-extensions"></a>Extensions <sup>[Back ⇈](#libraries-frameworks-extensions-subcategory)</sup>
 * [Kotlin/kotlinx.support](https://github.com/Kotlin/kotlinx.support) - Extension and top-level functions to use JDK7/JDK8 features in Kotlin 1.0.

--- a/src/main/resources/links/Libraries.kts
+++ b/src/main/resources/links/Libraries.kts
@@ -1235,6 +1235,13 @@ category("Libraries/Frameworks") {
       type = github
       tags = Tags["state machine"]
     }
+    link {
+      name = "charleskorn/kaml"
+      desc = "YAML support for kotlinx.serialization"
+      href = "https://github.com/charleskorn/kaml"
+      type = github
+      tags = Tags["serialization", "yaml"]
+    }
   }
   subcategory("Extensions") {
     link {


### PR DESCRIPTION
[kaml](https://github.com/charleskorn/kaml) is a library that adds YAML support to kotlinx.serialization.