### PR TITLE
Adding kotlin-multiplatform-bignum. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,6 @@ Here awesome badge for your project:
 * [sandjelkovic/kxjtime](https://github.com/sandjelkovic/kxjtime) - Lightweight Kotlin extensions for java.time API
 * [pmwmedia/tinylog](https://github.com/pmwmedia/tinylog) - Lightweight logging framework with native logging API for Kotlin.
 
-
 ### <a name="libraries-frameworks-raspberry-pi"></a>Raspberry Pi<sup>[Back ⇈](#libraries-frameworks-raspberry-pi-subcategory)</sup>
 * [mhashim6/Pi4K](https://github.com/mhashim6/Pi4K) - Pi4J Kotlin bindings.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Here awesome badge for your project:
 * <a name="libraries-frameworks-game-development-subcategory"></a>[Game Development](#libraries-frameworks-game-development)
 * <a name="libraries-frameworks-misc-subcategory"></a>[Misc](#libraries-frameworks-misc)
 * <a name="libraries-frameworks-raspberry-pi-subcategory"></a>[Raspberry Pi](#libraries-frameworks-raspberry-pi)
+* <a name="libraries-frameworks-multiplatform-subcategory"></a>[Multiplatform](#libraries-frameworks-multiplatform)
 * <a name="libraries-frameworks-extensions-subcategory"></a>[Extensions](#libraries-frameworks-extensions)
 * <a name="libraries-frameworks-configuration-subcategory"></a>[Configuration](#libraries-frameworks-configuration)
 * <a name="libraries-frameworks-graphics-subcategory"></a>[Graphics](#libraries-frameworks-graphics)
@@ -417,8 +418,12 @@ Here awesome badge for your project:
 * [sandjelkovic/kxjtime](https://github.com/sandjelkovic/kxjtime) - Lightweight Kotlin extensions for java.time API
 * [pmwmedia/tinylog](https://github.com/pmwmedia/tinylog) - Lightweight logging framework with native logging API for Kotlin.
 
+
 ### <a name="libraries-frameworks-raspberry-pi"></a>Raspberry Pi<sup>[Back ⇈](#libraries-frameworks-raspberry-pi-subcategory)</sup>
 * [mhashim6/Pi4K](https://github.com/mhashim6/Pi4K) - Pi4J Kotlin bindings.
+
+### <a name="libraries-frameworks-multiplatform"></a>Multiplatform<sup>[Back ⇈](#libraries-frameworks-multiplatform-subcategory)</sup>
+* [ionspin/kotlin-multiplatform-bignum](https://github.com/ionspin/kotlin-multiplatform-bignum) - Pure kotlin multiplatform arbitrary precision arithmetic library.
 
 ### <a name="libraries-frameworks-extensions"></a>Extensions <sup>[Back ⇈](#libraries-frameworks-extensions-subcategory)</sup>
 * [Kotlin/kotlinx.support](https://github.com/Kotlin/kotlinx.support) - Extension and top-level functions to use JDK7/JDK8 features in Kotlin 1.0.

--- a/src/main/resources/links/Libraries.kts
+++ b/src/main/resources/links/Libraries.kts
@@ -1351,6 +1351,15 @@ category("Libraries/Frameworks") {
       tags = Tags["raspberry-pi", "raspberrypi", "gpio", "dsl", "pi4j"]
     }
   }
+  subcategory("Multiplatform") {
+    link {
+      name = "ionspin/kotlin-multiplatform-bignum"
+      desc = "Pure kotlin multiplatform arbitrary precision arithmetic library."
+      href = "https://github.com/ionspin/kotlin-multiplatform-bignum"
+      type = github
+      tags = Tags["multiplatform", "bignum", "biginteger", "bigdecimal", "arbitrary-precision"]
+    }
+  }
   subcategory("Extensions") {
     link {
       name = "Kotlin/kotlinx.support"


### PR DESCRIPTION
This solves #436
Since this is a pure multiplatform library, and doesn't really fit into other categories, I added a new category called "Multiplatform".