### PR TITLE
Updated KGraphQL to new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Here awesome badge for your project:
 * [Kotlin/kotlinx.html](https://github.com/Kotlin/kotlinx.html) - Kotlin DSL for HTML.
 * [MarioAriasC/KotlinPrimavera](https://github.com/MarioAriasC/KotlinPrimavera) - Spring support libraries for Kotlin.
 * [kohesive/kovert](https://github.com/kohesive/kovert) - An invisible, super easy and powerful REST and Web framework over Vert.x or Undertow.
-* [pgutkowski/KGraphQL](https://github.com/pgutkowski/KGraphQL) - A GraphQL implementation written in Kotlin
+* [aPureBase/KGraphQL](https://github.com/aPureBase/KGraphQL) - A GraphQL implementation written in Kotlin
 * [taskworld/kraph](https://github.com/taskworld/kraph) - GraphQL request string builder written in Kotlin
 * [sepatel/tekniq](https://github.com/sepatel/tekniq) - Full-feature HTTP DSL Framework, HTTP Client, JDBC DSL, Loading Cache and Configuration
 * [vert-x3/vertx-lang-kotlin](https://github.com/vert-x3/vertx-lang-kotlin/) - This module provides Kotlin language bindings including DSL and extension functions for vert.x 3

--- a/src/main/resources/links/Libraries.kts
+++ b/src/main/resources/links/Libraries.kts
@@ -67,9 +67,9 @@ category("Libraries/Frameworks") {
       tags = Tags["web", "http", "rest", "vert.x", "undertow"]
     }
     link {
-      name = "pgutkowski/KGraphQL"
+      name = "aPureBase/KGraphQL"
       desc = "A GraphQL implementation written in Kotlin"
-      href = "https://github.com/pgutkowski/KGraphQL"
+      href = "https://github.com/aPureBase/KGraphQL"
       type = github
       tags = Tags["graphql", "web"]
     }
@@ -1566,7 +1566,7 @@ category("Libraries/Frameworks") {
       href = "https://github.com/java-opengl-labs/learn-OpenGL"
       type = github
       tags = Tags["opengl", "tutorial", "lwjgl"]
-    }    
+    }
     link {
       name = "java-opengl-labs/Vulkan"
       desc = "port of https://github.com/SaschaWillems/Vulkan"


### PR DESCRIPTION
The original repository has been archived, and this one has taken the over the development as seen at the top of the old [README.md](https://github.com/pgutkowski/KGraphQL#disclaimer)