### PR TITLE
Fix rx-brainwaves name

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ Here awesome badge for your project:
 * [adrielcafe/AndroidCoroutineScopes](https://github.com/adrielcafe/AndroidCoroutineScopes) - This lib implements the most common CoroutineScopes used in Android apps.
 * [WindSekirun/RxSocialLogin](https://github.com/WindSekirun/RxSocialLogin) - This Android library is a library that provides social login for 15 platforms powered by RxJava2, Kotlin and Firebase Authentication. 
 * [bakhtiyork/gradients](https://github.com/bakhtiyork/gradients) - A curated collection of splendid gradients
-* [hpost/RxBrainwaves](https://github.com/hpost/rx-brainwaves) - RxJava wrapper for NeuroSky MindWave headsets
+* [hpost/rx-brainwaves](https://github.com/hpost/rx-brainwaves) - RxJava wrapper for NeuroSky MindWave headsets
 * [adrielcafe/KrumbsView](https://github.com/adrielcafe/KrumbsView) - The ultimate breadcrumbs view for Android!
 * [inshiro/Skate](https://github.com/inshiro/skate) - A simple and easy to use Android fragment stack controller
 * [cortinico/slidetoact](https://github.com/cortinico/slidetoact) - A simple 'Slide to Unlock' Material widget for Android, written in Kotlin

--- a/src/main/resources/links/Android.kts
+++ b/src/main/resources/links/Android.kts
@@ -344,7 +344,7 @@ category("Android") {
       tags = Tags["android", "gradient", "drawable"]
     }
     link {
-      name = "hpost/RxBrainwaves"
+      name = "hpost/rx-brainwaves"
       desc = "RxJava wrapper for NeuroSky MindWave headsets"
       href = "https://github.com/hpost/rx-brainwaves"
       type = github


### PR DESCRIPTION
Previously GitHub stars were not able to be pulled in due to the differently formatted name.