### PR TITLE
Added Krush persistence library

### DIFF
--- a/readme/README.md
+++ b/readme/README.md
@@ -287,6 +287,7 @@ Here awesome badge for your project:
 * [fluidsonic/fluid-mongo](https://github.com/fluidsonic/fluid-mongo) - Coroutine support for MongoDB built on top of the official MongoDB Asynchronous Java Driver.
 * [jasync-sql/jasync-sql](https://github.com/jasync-sql/jasync-sql) - Kotlin port of mauricio's async driver for postgres/mysql.
 * [vincentlauvlwj/Ktorm](https://github.com/vincentlauvlwj/Ktorm) - A lightweight and efficient ORM Framework for Kotlin. It provides strong typed and flexible SQL DSL and many convenient extension functions to reduce our duplicated effort on database operations. 
+* [TouK/krush](https://github.com/TouK/krush) - Idiomatic persistence layer for Kotlin, based on Exposed. It’s based on a compile-time JPA annotation processor that generates Exposed DSL table and objects mappings from your data classes.
 
 ### <a name="libraries-frameworks-tools"></a>Tools <sup>[Back ⇈](#libraries-frameworks-tools-subcategory)</sup>
 * [SonarSource/sonarlint-intellij](https://github.com/SonarSource/sonarlint-intellij) - An IDE extension that helps you detect and fix quality issues as you write code.


### PR DESCRIPTION
Hi, added our new library [Krush](https://github.com/TouK/krush) based on Exposed - you can find more in the README or in [this blog post](https://touk.pl/blog/2019/12/30/announcing-krush%e2%80%8a-%e2%80%8aidiomatic-persistence-layer-for-kotlin-based-on-exposed/)

- [X] Is this pull request against the branch `master`?
