### PR TITLE
Update detekt's link

### DIFF
--- a/src/main/resources/links/Libraries.kts
+++ b/src/main/resources/links/Libraries.kts
@@ -967,9 +967,9 @@ category("Libraries/Frameworks") {
       tags = Tags["aot", "compiller"]
     }
     link {
-      name = "arturbosch/detekt"
+      name = "detekt/detekt"
       desc = "Static code analysis for Kotlin."
-      href = "https://github.com/arturbosch/detekt"
+      href = "https://github.com/detekt/detekt"
       type = github
       tags = Tags["check style", "checkstyle"]
     }


### PR DESCRIPTION
Detekt project has been moved under [detekt organization](https://github.com/detekt) which makes relevant detekt's link to be: https://github.com/detekt/detekt

Make sure that you making pull request against [`legacy`](https://github.com/KotlinBy/awesome-kotlin/tree/legacy) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `legacy`. Consult [CONTRIBUTING.md](https://github.com/KotlinBy/awesome-kotlin/blob/legacy/CONTRIBUTING.md) for details.

Checklist: 

- [x] Is this pull request against the branch `legacy`?
