### PR TITLE
Add Themis [cryptography]

### DIFF
--- a/src/main/resources/links/Android.kts
+++ b/src/main/resources/links/Android.kts
@@ -800,6 +800,13 @@ category("Android") {
       href = "https://github.com/Reedyuk/blue-falcon"
       type = github
       tags = Tags["bluetooth", "kotlin multiplatform", "android", "ios"]
+    }    
+    link {
+      name = "cossacklabs/themis"
+      desc = "Multi-language framework for solving typical data security tasks: storage and messaging encryption, authentication, works for 14 languages."
+      href = "https://github.com/cossacklabs/themis"
+      type = github
+      tags = Tags["security", "cryptography", "crypto". "encryption", "kotlin multiplatform", "android", "ios"]
     }
   }
 }


### PR DESCRIPTION
Adding Themis to Android multi-platform section.

Themis makes data encryption easy. It supports multiple client-side platforms (mobile and web) and different server-side platforms; suits for building end-to-end encrypted applications. Best choice for multi-platform apps. Hides cryptographic details, so developers don't need to know the difference between AES CBC mode and AES GCM mode to encrypt the data. Recommended by OWASP MASVS.

Checklist: 

- [x] Is this pull request against the branch `legacy`?
