### PR TITLE
Fix Javascript/three.kt and add Libraries/three.kt

### DIFF
--- a/src/main/resources/links/JavaScript.kts
+++ b/src/main/resources/links/JavaScript.kts
@@ -56,9 +56,9 @@ category("Kotlin JavaScript") {
       tags = Tags["boilerplate", "javascript", "kotlin2js"]
     }
     link {
-      name = "markaren/three.kt"
+      name = "markaren/three-kt-wrapper"
       desc = "Kotlin wrappers for three.js JavaScript 3D library"
-      href = "https://github.com/markaren/three.kt"
+      href = "https://github.com/markaren/three-kt-wrapper"
       type = github
       tags = Tags["web", "javascript", "kotlin-js", "three-js"]
     }

--- a/src/main/resources/links/Libraries.kts
+++ b/src/main/resources/links/Libraries.kts
@@ -1943,6 +1943,13 @@ category("Libraries/Frameworks") {
       type = github
       tags = Tags["opengl", "creative-coding", "kotlin", "dsl", "shaders", "ljwgl"]
     }
+    link {
+      name = "markaren/three.kt"
+      desc = "Kotlin port of three.js JavaScript 3D library"
+      href = "https://github.com/markaren/three.kt"
+      type = github
+      tags = Tags["opengl", "lwjgl3", "three-js"]
+    }
   }
   subcategory("Data Science") {
     link {


### PR DESCRIPTION
Old three.kt (kotlin Javascript wrapper) was renamed to three-kt-wrapper and three.kt now points to a full fledged port of three.js for Kotlin/JVM (although the repository is set up for multi-platform) 