### PR TITLE
Fix typo in GitHub links

### DIFF
--- a/src/main/kotlin/link/kotlin/scripts/LinksProcessor.kt
+++ b/src/main/kotlin/link/kotlin/scripts/LinksProcessor.kt
@@ -39,7 +39,7 @@ private class DefaultLinksProcessor(
                 if (meta.pushedAt != null) {
                     link.copy(
                         name = link.name ?: link.github,
-                        href = link.href ?: "https://githib.com/${link.github}",
+                        href = link.href ?: "https://github.com/${link.github}",
                         desc = link.desc ?: meta.description,
                         star = meta.stargazersCount,
                         update = parseInstant(meta.pushedAt).format(formatter),


### PR DESCRIPTION
This PR fixes #591 which causes most links to be broken.