### PR TITLE
Adding "cqfn/diktat" to the list of Kotlin libraries

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -789,6 +789,12 @@ category("Libraries/Frameworks") {
       setTags("style", "linter")
       awesome()
     }
+	link {
+      github = "cqfn/diktat"
+      desc = "Strict coding standard for Kotlin and a custom set of rules for detecting and autofixing code smells."
+      setTags("style", "linter", "static-analysis", "check style", "code smell")
+      awesome()
+    }
     link {
       github = "jtransc/jtransc"
       desc = "JVM AOT compiler created in Kotlin."


### PR DESCRIPTION
### What is diKTat:
1) Diktat is a formal and strict code style for Kotlin.
2) DiKTat is a collection of Kotlin code style rules implemented as AST visitors on top of KTlint framework. This linter can validate (check) and automatically fix (format) the code.
3) DiKTat can be run as maven plugin/gradle plugin/cli

Checklist: 
- [x] Is this pull request against the branch `main`?
