### PR TITLE
Rename PlotAssert to vis-assert

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -318,7 +318,7 @@ category("Libraries/Frameworks") {
       setTags("test", "html", "template", "dom", "dsl", "parser", "webcrawler", "scraper", "ktor", "spring-boot")
     }
     link {
-      github = "krzema12/PlotAssert"
+      github = "krzema12/vis-assert"
       desc = "Test the shape of your functions!"
       setTags("test", "testing", "dsl", "ascii-art")
     }


### PR DESCRIPTION
I renamed the library because of issues with JCenter, and also
to give it a more generic name for future use cases.

Make sure that you are making pull request against [`main`](https://github.com/KotlinBy/awesome-kotlin/tree/main) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `main` branch. Consult [contributing.md](https://github.com/KotlinBy/awesome-kotlin/blob/main/.github/contributing.md) for details.

Checklist: 

- [x] Is this pull request against the branch `main`?
