### PR TITLE
Add bluefireoly/SimpleKotlinMail to libraries

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1799,4 +1799,12 @@ category("Libraries/Frameworks") {
       setPlatforms(JVM, JS, ANDROID, NATIVE, IOS, COMMON)
     }
   }
+  subcategory("Mail") {
+    link {
+      github = "bluefireoly/SimpleKotlinMail"
+      desc = "A simple, modern and coroutine based Kotlin Email API, supporting both clientside and serverside projects."
+      setTags("mail", "smtp", "email", "mailserver")
+      setPlatforms(JVM)
+    }
+  }
 }


### PR DESCRIPTION
This pull requests adds a new subcategory to libraries: "Mail"
It also adds [SimpleKotlinMail](https://github.com/bluefireoly/SimpleKotlinMail) to this category.

Checklist: 

- [x] Is this pull request against the branch `main`?
