### PR TITLE
Fix Chucker description

### DIFF
--- a/src/main/resources/links/Android.awesome.kts
+++ b/src/main/resources/links/Android.awesome.kts
@@ -279,7 +279,7 @@ category("Android") {
     }
     link {
       github = "ChuckerTeam/chucker"
-      desc = "An on-device HTTP and Throwable inspector for Android."
+      desc = "An on-device network inspection tool for Android."
     }
     link {
       github = "rosariopfernandes/firecoil"


### PR DESCRIPTION
Fixing Chucker description to not confuse people as it is already quite a long time since we deprecated and removed Throwable inspection from the library making Chucker only network inspection tool
