### PR TITLE
Update "konsole" to "kotter"

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1863,8 +1863,10 @@ category("Libraries/Frameworks") {
       setPlatforms(JVM, JS, NATIVE, COMMON)
     }
     link {
-      github = "varabyte/konsole"
+      github = "varabyte/kotter"
       desc = "A declarative, Kotlin-idiomatic API for writing dynamic command line applications"
+      setTags("cli", "ansi", "color")
+      setPlatforms(JVM)
     }
     link {
       github = "kotlin-inquirer/kotlin-inquirer"


### PR DESCRIPTION
I originally started writing a project called "konsole" but after
people pointed out there was already a clashing open-source project
in KDE called "konsole", I renamed it to "kotter", short for
"KOTlin TERminal"

While I was at it, I added some additional relevant metadata to the
project entry.

Make sure that you are making pull request against [`main`](https://github.com/KotlinBy/awesome-kotlin/tree/main) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `main` branch. Consult [contributing.md](https://github.com/KotlinBy/awesome-kotlin/blob/main/.github/contributing.md) for details.

Checklist: 

- [x] Is this pull request against the branch `main`?
