### PR TITLE
Add kotlin-multiplatform-diff

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1514,6 +1514,12 @@ category("Libraries/Frameworks") {
       desc = "Kotlin multiplatform wrapper for Libsodium cryptographic library."
       setTags("multiplatform", "libsodium", "cryptography")
     }
+    link {
+      github = "petertrr/kotlin-multiplatform-diff"
+      desc = "Multiplatform kotlin library for calculating text differences. Based on java-diff-utils."
+      setTags("multiplatform", "tools", "text", "diff", "myers", "algorithm")
+      setPlatforms(COMMON, JVM, JS, NATIVE)
+    }
   }
   subcategory("Extensions") {
     link {


### PR DESCRIPTION
kotlin-multiplatform-diff is a multiplatform kotlin library for calculating text differences. It's based on java-diff-utils and it's built for JVM, Native and JS.