### PR TITLE
Add Model Forge Testing Library

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -387,6 +387,11 @@ category("Libraries/Frameworks") {
       setPlatforms(JVM)
       setTags("scraper", "parser", "webcrawler", "chefkoch", "api")
     }
+    link {
+      github = "HelloCuriosity/model-forge"
+      desc = "A Kotlin library for auto generating models for tests."
+      setTags("test", "model-generation", "fixtures")
+    }
   }
   subcategory("Mocks and Fakes") {
     link {


### PR DESCRIPTION
This adds Model Forge to the list of libraries. It's a kotlin library that auto generates models for tests so that you don't have to do it by hand.

Checklist: 

- [x] Is this pull request against the branch `main`?
