### PR TITLE
Add wavy slider

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -2197,5 +2197,11 @@ category("Libraries/Frameworks") {
       setTags("jetpack-compose", "compose", "kotlin", "jetpack-android", "android")
       setPlatforms(ANDROID)
     }
+    link{
+      github = "mahozad/wavy-slider"
+      desc = "Multiplatform UI widget that recreates the Android 13 squiggly progress bar"
+      setTags("jetpack-compose", "compose", "kotlin", "compose-desktop", "ui")
+      setPlatforms(JVM, ANDROID, JS)
+    }
   }
 }


### PR DESCRIPTION
![A decorative demo](https://raw.githubusercontent.com/mahozad/wavy-slider/master/demo.svg)

This is a multiplatform Compose UI component that demonstrates how to develop UI widgets targeting multiple platforms.

It currently supports Android, Desktop JVM (Windows, Linux, macOS), and JavaScript canvas (WASM).

Checklist: 

- [x] Is this pull request against the branch `main`?
