### PR TITLE
Update Node version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.5.1
+          node-version: 20.x
       - run: yarn install --check-cache
         working-directory: app-frontend
   build:
@@ -45,7 +45,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.5.1
+          node-version: 20.x
       - run: yarn install
         working-directory: app-frontend
       - run: yarn run build


### PR DESCRIPTION
Changed the specific node-version in the .github/workflows/build.yml file from 20.5.1 to a more flexible 20.x. This allows the workflow to use the latest stable version of Node 20, ensuring compatibility with latest features and security patches.

Make sure that you are making pull request against [`main`](https://github.com/KotlinBy/awesome-kotlin/tree/main) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `main` branch. Consult [contributing.md](https://github.com/KotlinBy/awesome-kotlin/blob/main/.github/contributing.md) for details.

Checklist: 

- [ ] Is this pull request against the branch `main`?
