### PR TITLE
Add Extra Ktor Plugins

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -9,6 +9,13 @@ category("Libraries/Frameworks") {
       awesome()
     }
     link {
+      github = "Flaxoos/flax-ktor-plugins"
+      href = "https://github.com/Flaxoos/flax-ktor-plugins"
+      desc = "A Ktor plugins repository for servers and clients, including a kafka client plugin, circuit breaker and more"
+      setPlatforms(JVM, ANDROID, NATIVE, IOS)
+      setTags("web", "mobile", "ktor", "plugins", "server", "client", "kafka", "rate-limiting", "circuit-breaker")
+    }
+    link {
       github = "darkredz/zeko-restapi-framework"
       setTags("web", "http", "rest", "vert.x", "swagger", "openapi", "microframework", "rest-api", "reactive", "mvc")
     }


### PR DESCRIPTION
Extending Ktor for the kotlin community:

While Kotlin is seeing widespread adoption, its web framework, Ktor, is sometimes overlooked, largely because Spring Boot still offers an exhaustive range of starters. To bridge this gap, kotlin fans like myself, could contribute to enhancing Ktor's functionality, which will increase adoption and further stimulate contribution by others. And so, I've developed a library of extra Ktor plugins.

Make sure that you are making pull request against [`main`](https://github.com/KotlinBy/awesome-kotlin/tree/main) branch. Pull requests against `readme` branch will not be accepted, because all manual changes to this branch will be overridden by changes from `main` branch. Consult [contributing.md](https://github.com/KotlinBy/awesome-kotlin/blob/main/.github/contributing.md) for details.

Checklist: 

- [X] Is this pull request against the branch `main`?
