### PR TITLE
Add Java Time Fun to Libraries.awesome.kts

### DIFF
--- a/src/main/resources/links/Libraries.awesome.kts
+++ b/src/main/resources/links/Libraries.awesome.kts
@@ -1293,6 +1293,11 @@ category("Libraries/Frameworks") {
       setTags("time", "date")
     }
     link {
+      github = "seljabali/java-time-fun"
+      desc = "java.time Kotlin extension functions library."
+      setTags("time", "date", "conversion")
+    }
+    link {
       github = "ingokegel/jclasslib"
       desc = "jclasslib bytecode viewer is a tool that visualizes all aspects of compiled Java class files and the contained bytecode."
       setTags("bytecode")


### PR DESCRIPTION
Checklist: 

- [x] Is this pull request against the branch `main`?

Added https://github.com/seljabali/java-time-fun, a java.time Kotlin extension functions library.
* Hosted on maven central.
* United tested.
* Used by apps in production.
