### PR TITLE
Add Casino Engine link to Projects.awesome.kts

### DIFF
--- a/src/main/resources/links/Projects.awesome.kts
+++ b/src/main/resources/links/Projects.awesome.kts
@@ -106,6 +106,12 @@ category("Projects") {
       desc = "A KTOR server/MCP server written in Kotlin applying multi-agents schools in a flexible research system"
       setTags("ktor", "mcp", "agents", "research", "server")
     }
+    link {
+      name = "Casino Engine"
+      desc = "Open-source iGaming game-mechanics engine — provider aggregator integrations, session, betting and freespin lifecycle. Powers casinos on 1638.cloud."
+      href = "https://github.com/nekzabirov/IGaming-Game-Engine"
+      tags { +"Kotlin" + "Ktor" + "gRPC" + "iGaming" }
+    }  
   }
   subcategory("Build tools") {
     link {


### PR DESCRIPTION
Adds Casino Engine — open-source iGaming game-mechanics engine — to `Projects.awesome.kts`.

## About the project

Casino Engine is a production-grade Kotlin microservice handling game session orchestration, provider/aggregator integrations (Pragmatic Play, OneGameHub, Pateplay), betting logic, freespin mechanics, and round lifecycle. Currently running in production on two live casinos: [moonbet.casino](https://moonbet.casino) and [2k.ua](https://2k.ua).

## Tech stack

- Kotlin 2.0.21 on JVM 21
- Ktor 3.0 (HTTP) + gRPC (RPC)
- PostgreSQL (Exposed ORM)
- RabbitMQ (event streaming)
- Redis (Lettuce)
- Koin (DI)
- Hexagonal architecture with CQRS

## Links

- **Repository:** https://github.com/nekzabirov/IGaming-Game-Engine
- **Licence:** Apache 2.0

---

Checklist:

- [x] Is this pull request against the branch `main`?